### PR TITLE
【FE #7】日記一覧画面のレイアウトのみ作成した。

### DIFF
--- a/next-front/src/app/diary/page.tsx
+++ b/next-front/src/app/diary/page.tsx
@@ -1,0 +1,12 @@
+export default function DiaryPage() {
+  return (
+    <div className="w-4/5 h-full mx-auto bg-yellow-300">
+      <h1 className="text-4xl text-center">日記</h1>
+      <div className="flex flex-col justify-center items-center">
+        <div>日記1</div>
+        <div>日記2</div>
+        <div>日記3</div>
+      </div>
+    </div>
+  );
+}

--- a/next-front/src/app/diary/page.tsx
+++ b/next-front/src/app/diary/page.tsx
@@ -1,8 +1,8 @@
 export default function DiaryPage() {
   return (
-    <div className="w-4/5 h-full mx-auto bg-yellow-300">
-      <h1 className="text-4xl text-center">日記</h1>
-      <div className="flex flex-col justify-center items-center">
+    <div className="w-4/5 h-full mx-auto pt-16 bg-yellow-300">
+      <h1 className="text-4xl text-left mb-5">日記</h1>
+      <div className="h-4/5 py-5 flex flex-col items-center bg-red-200">
         <div>日記1</div>
         <div>日記2</div>
         <div>日記3</div>

--- a/next-front/src/app/diary/page.tsx
+++ b/next-front/src/app/diary/page.tsx
@@ -6,6 +6,7 @@ export default function DiaryPage() {
       <PageHeader type="h1" textAlignment="left">
         日記
       </PageHeader>
+      <h2 className=" text-4xl text-center">7/25 (木)</h2>
       <div className="h-4/5 py-5 flex flex-col items-center">
         <div>日記1</div>
         <div>日記2</div>

--- a/next-front/src/app/diary/page.tsx
+++ b/next-front/src/app/diary/page.tsx
@@ -1,8 +1,12 @@
+import PageHeader from "@/components/typography/pageHeader";
+
 export default function DiaryPage() {
   return (
-    <div className="w-4/5 h-full mx-auto pt-16 bg-yellow-300">
-      <h1 className="text-4xl text-left mb-5">日記</h1>
-      <div className="h-4/5 py-5 flex flex-col items-center bg-red-200">
+    <div className="w-4/5 max-w-600 h-full mx-auto pt-14 bg-stone-50">
+      <PageHeader type="h1" textAlignment="left">
+        日記
+      </PageHeader>
+      <div className="h-4/5 py-5 flex flex-col items-center">
         <div>日記1</div>
         <div>日記2</div>
         <div>日記3</div>

--- a/next-front/src/app/globals.css
+++ b/next-front/src/app/globals.css
@@ -1,3 +1,9 @@
 @tailwind base;
 @tailwind components;
 @tailwind utilities;
+
+html,
+body,
+#__next {
+  height: 100%;
+}

--- a/next-front/tailwind.config.js
+++ b/next-front/tailwind.config.js
@@ -2,7 +2,11 @@
 module.exports = {
   content: ["./src/**/*.{js,ts,jsx,tsx,mdx}"],
   theme: {
-    extend: {},
+    extend: {
+      maxWidth: {
+        600: "600px",
+      },
+    },
   },
   plugins: [],
 };


### PR DESCRIPTION
# 変更
* `app/diary/page.tsx`に、日記一覧画面のレイアウトのみ作成した。
* カスタムのクラスを定義した。
* 全体にかかるcssを追記した。

# 確認方法
*/diary/`にアクセスして、日記一覧画面が見れることを確認する。

# 注意
issueはまだ終わっていない。他のコンポーネントが出来次第、別のブランチで続きに取り組む

# issue
#7 
