### PR TITLE
delete-migrate

### DIFF
--- a/rails-api/db/migrate/20240727120830_addtokens_user.rb
+++ b/rails-api/db/migrate/20240727120830_addtokens_user.rb
@@ -1,5 +1,0 @@
-class AddtokensUser < ActiveRecord::Migration[7.0]
-  def change
-    add_column :users, :tokens, :text
-  end
-end


### PR DESCRIPTION
同じモデルのカラムを変更するmigrationファイルが２つ作成されていたため、一つを削除しました。