### PR TITLE
【FE #5】新規登録画面とログイン画面を作成した

### DIFF
--- a/next-front/src/app/auth/page.tsx
+++ b/next-front/src/app/auth/page.tsx
@@ -13,7 +13,14 @@ export default function AuthPage() {
   const [email, setEmail] = useState<string>("");
   const [password, setPassword] = useState<string>("");
 
+  const [blankError, setBlankError] = useState<boolean>(false);
+
   const handleAuth = async () => {
+    if (email === "" || password === "") {
+      setBlankError(true);
+      return;
+    }
+    setBlankError(false);
     //TODO: 新規登録処理を書く
     location.href = "/home";
   };
@@ -42,6 +49,11 @@ export default function AuthPage() {
           value={password}
           onChange={(e) => setPassword(e.target.value)}
         />
+        {blankError && (
+          <div className="w-full h-12 bg-red-600 text-white text-center rounded-md">
+            メールアドレスとパスワード両方を入力してください
+          </div>
+        )}
       </div>
       <div className="w-4/5 max-w-600 h-1/5 mx-auto flex flex-row gap-x-10 justify-center items-center">
         <CircleButton

--- a/next-front/src/app/auth/page.tsx
+++ b/next-front/src/app/auth/page.tsx
@@ -40,7 +40,7 @@ export default function AuthPage() {
           Icon={ArrowBackIosNewIcon}
         />
         <CircleButton
-          label="戻る"
+          label="登録"
           fontsize="60px"
           color="#fff"
           backgroundColor="#1A85D1"

--- a/next-front/src/app/auth/page.tsx
+++ b/next-front/src/app/auth/page.tsx
@@ -1,0 +1,52 @@
+"use client";
+
+import { CircleButton } from "@/components/button/circleButton";
+import PageHeader from "@/components/typography/pageHeader";
+import { CheckRounded } from "@mui/icons-material";
+import ArrowBackIosNewIcon from "@mui/icons-material/ArrowBackIosNew";
+import { useState } from "react";
+
+export default function AuthPage() {
+  const [email, setEmail] = useState<string>("");
+  const [password, setPassword] = useState<string>("");
+
+  return (
+    <div className="w-4/5 max-w-600 h-full mx-auto pt-14 bg-stone-50">
+      <PageHeader type="h1" textAlignment="center">
+        新規登録
+      </PageHeader>
+      <div className="h-3/5 w-4/5 py-5 mx-auto gap-y-3 flex flex-col items-center">
+        <input
+          type="text"
+          placeholder="メールアドレス"
+          className="w-full h-12 border border-gray-300 rounded-md px-2"
+          value={email}
+          onChange={(e) => setEmail(e.target.value)}
+        />
+        <input
+          type="password"
+          placeholder="パスワード"
+          className="w-full h-12 border border-gray-300 rounded-md px-2"
+          value={password}
+          onChange={(e) => setPassword(e.target.value)}
+        />
+      </div>
+      <div className="w-4/5 max-w-600 h-1/5 mx-auto flex flex-row gap-x-10 justify-center items-center">
+        <CircleButton
+          label="戻る"
+          fontsize="60px"
+          color="#fff"
+          backgroundColor="#999999"
+          Icon={ArrowBackIosNewIcon}
+        />
+        <CircleButton
+          label="戻る"
+          fontsize="60px"
+          color="#fff"
+          backgroundColor="#1A85D1"
+          Icon={CheckRounded}
+        />
+      </div>
+    </div>
+  );
+}

--- a/next-front/src/app/auth/page.tsx
+++ b/next-front/src/app/auth/page.tsx
@@ -1,5 +1,7 @@
 "use client";
 
+import { useRouter } from "next/navigation";
+
 import { CircleButton } from "@/components/button/circleButton";
 import PageHeader from "@/components/typography/pageHeader";
 import { CheckRounded } from "@mui/icons-material";
@@ -7,8 +9,18 @@ import ArrowBackIosNewIcon from "@mui/icons-material/ArrowBackIosNew";
 import { useState } from "react";
 
 export default function AuthPage() {
+  const router = useRouter();
   const [email, setEmail] = useState<string>("");
   const [password, setPassword] = useState<string>("");
+
+  const handleAuth = async () => {
+    //TODO: 新規登録処理を書く
+    location.href = "/home";
+  };
+
+  const handleBack = () => {
+    router.push("/");
+  };
 
   return (
     <div className="w-4/5 max-w-600 h-full mx-auto pt-14 bg-stone-50">
@@ -38,6 +50,7 @@ export default function AuthPage() {
           color="#fff"
           backgroundColor="#999999"
           Icon={ArrowBackIosNewIcon}
+          onClick={handleBack}
         />
         <CircleButton
           label="登録"
@@ -45,6 +58,7 @@ export default function AuthPage() {
           color="#fff"
           backgroundColor="#1A85D1"
           Icon={CheckRounded}
+          onClick={handleAuth}
         />
       </div>
     </div>

--- a/next-front/src/app/sign-in/page.tsx
+++ b/next-front/src/app/sign-in/page.tsx
@@ -7,9 +7,21 @@ import { useState } from "react";
 import { CheckRounded } from "@mui/icons-material";
 import ArrowBackIosNewIcon from "@mui/icons-material/ArrowBackIosNew";
 
+import { useRouter } from "next/navigation";
+
 export default function SignInPage() {
+  const router = useRouter();
   const [email, setEmail] = useState<string>("");
   const [password, setPassword] = useState<string>("");
+
+  const handleSignIn = async () => {
+    //TODO: ログイン処理を書く
+    location.href = "/home";
+  };
+
+  const handleBack = () => {
+    router.push("/");
+  };
 
   return (
     <div className="w-4/5 max-w-600 h-full mx-auto pt-14 bg-stone-50">
@@ -39,6 +51,7 @@ export default function SignInPage() {
           color="#fff"
           backgroundColor="#999999"
           Icon={ArrowBackIosNewIcon}
+          onClick={handleBack}
         />
         <CircleButton
           label="ログイン"
@@ -46,6 +59,7 @@ export default function SignInPage() {
           color="#fff"
           backgroundColor="#1A85D1"
           Icon={CheckRounded}
+          onClick={handleSignIn}
         />
       </div>
     </div>

--- a/next-front/src/app/sign-in/page.tsx
+++ b/next-front/src/app/sign-in/page.tsx
@@ -14,7 +14,14 @@ export default function SignInPage() {
   const [email, setEmail] = useState<string>("");
   const [password, setPassword] = useState<string>("");
 
+  const [blankError, setBlankError] = useState<boolean>(false);
+
   const handleSignIn = async () => {
+    if (email === "" || password === "") {
+      setBlankError(true);
+      return;
+    }
+    setBlankError(false);
     //TODO: ログイン処理を書く
     location.href = "/home";
   };
@@ -43,6 +50,11 @@ export default function SignInPage() {
           value={password}
           onChange={(e) => setPassword(e.target.value)}
         />
+        {blankError && (
+          <div className="w-full h-12 bg-red-600 text-white text-center rounded-md">
+            メールアドレスとパスワード両方を入力してください
+          </div>
+        )}
       </div>
       <div className="w-4/5 max-w-600 h-1/5 mx-auto flex flex-row gap-x-10 justify-center items-center">
         <CircleButton

--- a/next-front/src/app/sign-in/page.tsx
+++ b/next-front/src/app/sign-in/page.tsx
@@ -1,0 +1,53 @@
+"use client";
+
+import { CircleButton } from "@/components/button/circleButton";
+import PageHeader from "@/components/typography/pageHeader";
+import { useState } from "react";
+
+import { CheckRounded } from "@mui/icons-material";
+import ArrowBackIosNewIcon from "@mui/icons-material/ArrowBackIosNew";
+
+export default function SignInPage() {
+  const [email, setEmail] = useState<string>("");
+  const [password, setPassword] = useState<string>("");
+
+  return (
+    <div className="w-4/5 max-w-600 h-full mx-auto pt-14 bg-stone-50">
+      <PageHeader type="h1" textAlignment="center">
+        ログイン
+      </PageHeader>
+      <div className="h-3/5 w-4/5 py-5 mx-auto gap-y-3 flex flex-col items-center">
+        <input
+          type="text"
+          placeholder="メールアドレス"
+          className="w-full h-12 border border-gray-300 rounded-md px-2"
+          value={email}
+          onChange={(e) => setEmail(e.target.value)}
+        />
+        <input
+          type="password"
+          placeholder="パスワード"
+          className="w-full h-12 border border-gray-300 rounded-md px-2"
+          value={password}
+          onChange={(e) => setPassword(e.target.value)}
+        />
+      </div>
+      <div className="w-4/5 max-w-600 h-1/5 mx-auto flex flex-row gap-x-10 justify-center items-center">
+        <CircleButton
+          label="戻る"
+          fontsize="60px"
+          color="#fff"
+          backgroundColor="#999999"
+          Icon={ArrowBackIosNewIcon}
+        />
+        <CircleButton
+          label="ログイン"
+          fontsize="60px"
+          color="#fff"
+          backgroundColor="#1A85D1"
+          Icon={CheckRounded}
+        />
+      </div>
+    </div>
+  );
+}


### PR DESCRIPTION
# 変更
* 新規登録画面を`app/auth/page.tsx`に作成した。
* ログイン画面を`app/sign_in/page.tsx`に作成した。
* フォームが空欄チェックを行うようにした。
* 新規登録で「登録」を押すと、`/home`へ遷移するようにした。
* ログインで「ログイン」を押すと、`/home`へ遷移するようにした。
* それぞれの画面で「戻る」を押すと、トップページ`/`へ遷移するようにした。

# 確認方法
* 各ページにアクセスし、問題なく表示・動作することを確認する。

# 注意点
事業内容とログインの画面では、入力欄はこのままでいきたいと思っています。
また別のブランチで、APIとの接続を行います。issue #31 

# issue
closed #5 