### PR TITLE
【FE #35】GPTを使って、質問を作らせるサンプルを作った。

### DIFF
--- a/next-front/src/app/test-create-q/page.tsx
+++ b/next-front/src/app/test-create-q/page.tsx
@@ -1,0 +1,48 @@
+"use client";
+
+import { DiaryData } from "@/types/daiaryData";
+
+import { useChatGpt } from "@/hooks/useChatGpt";
+import { useState } from "react";
+
+export default function TestCreateQPage() {
+  const [questions, setQuestions] = useState<string[]>([]);
+
+  const { connectChatGpt } = useChatGpt();
+  const sampleData: DiaryData = {
+    id: 1,
+    actionName: "朝のランニング",
+    actionDetail: "公園を30分間ランニングしました。",
+    originality: "新しいランニングルートを試しました。",
+    getSomething: "爽やかな気分と達成感",
+    questionOne: "今日のランニングの目標は？",
+    answerOne: "30分間走ること",
+    questionTwo: "ランニング中に気づいたことは？",
+    answerTwo: "新しいルートにはたくさんの花が咲いている",
+    imgUrl: "https://example.com/running.jpg",
+    isBestDiary: 1,
+    startTime: "06:00",
+    endTime: "06:30",
+    date: "2024-07-27",
+  };
+
+  const createQuestion = (data: DiaryData) => {
+    const pronpt = `次の日記に対して、自己分析につながるような質問3つを考えてください。質問だけをカンマ区切りで出力してください。タイトル: ${data.actionName}, 詳細: ${data.actionDetail}, 工夫点: ${data.originality}, 得られたもの: ${data.getSomething}`;
+    connectChatGpt(pronpt).then((res) => {
+      //resをカンマ区切りで分割して配列に格納
+      const questions = res.split(",");
+      console.log(questions);
+      setQuestions(questions);
+    });
+  };
+
+  return (
+    <div>
+      <h1>作成した問題を出力</h1>
+      <button onClick={() => createQuestion(sampleData)}>質問を作成</button>
+      {questions.map((question, index) => (
+        <p key={index}>{question}</p>
+      ))}
+    </div>
+  );
+}

--- a/next-front/src/hooks/useChatGpt.tsx
+++ b/next-front/src/hooks/useChatGpt.tsx
@@ -1,0 +1,31 @@
+export const useChatGpt = () => {
+  const apiKey = process.env.NEXT_PUBLIC_GPT_API_KEY;
+
+  const connectChatGpt = async (message: string) => {
+    try {
+      const res = await fetch("https://api.openai.com/v1/chat/completions", {
+        method: "POST",
+        headers: {
+          "Content-Type": "application/json",
+          Authorization: `Bearer ${apiKey}`,
+        },
+        body: JSON.stringify({
+          model: "gpt-3.5-turbo-0125",
+          messages: [{ role: "user", content: message }],
+          temperature: 0.7,
+        }),
+      });
+
+      const json = await res.json();
+      const responseMessage = json.choices[0].message.content.replace(
+        /<br>/g,
+        "\n"
+      );
+      return responseMessage;
+    } catch (error) {
+      return "error";
+    }
+  };
+
+  return { connectChatGpt };
+};


### PR DESCRIPTION
# 変更
* ChatGPTを使うhooksを配置した。（`hooks/useChatGpt`）
* これを用いて質問を作らせたり、帰ってきたものを展開するサンプルページ（`app/test-create-q.tsx`）を作成した。

# 確認方法
* ページにアクセスして「質問を作成」を押すと、作られた質問が表示されることを確認する。

# issue
#35